### PR TITLE
Prepare for QUnit 3.0

### DIFF
--- a/.changeset/violet-coats-wink.md
+++ b/.changeset/violet-coats-wink.md
@@ -1,0 +1,5 @@
+---
+"qunit-theme-ember": minor
+---
+
+Prepare CSS for QUnit 3.0 compat

--- a/qunit.css
+++ b/qunit.css
@@ -87,7 +87,8 @@ body {
   color: var(--color-gray-900);
 }
 
-#qunit-userAgent {
+/* QUnit 2 only */
+#qunit > #qunit-userAgent {
   background-color: var(--color-gray-100);
   color: var(--color-gray-900);
   text-shadow: none;
@@ -142,16 +143,8 @@ body {
   color: var(--color-gray-900);
 }
 
-#qunit-tests li {
+#qunit-tests > li {
   background-color: var(--color-gray-100);
-}
-
-#qunit-tests .pass {
-  color: var(--color-gray-900);
-}
-
-#qunit-tests .pass .test-name {
-  color: var(--color-gray-700);
 }
 
 #qunit-tests li {
@@ -160,33 +153,42 @@ body {
   border-bottom: 0;
 }
 
-#qunit-tests li li.pass {
+#qunit-tests > li.pass {
+  color: var(--color-gray-900);
+  background-color: var(--color-success);
+}
+
+#qunit-tests > li.pass .test-name {
+  color: var(--color-gray-700);
+}
+
+#qunit-tests > li.fail {
+  background-color: var(--color-danger);
+}
+
+#qunit-tests > li.fail .test-expected {
+  color: var(--color-green);
+}
+
+#qunit-tests > li.fail .test-actual {
+  color: var(--color-red);
+}
+
+.qunit-assert-list {
+  margin: 10px 0;
+}
+
+#qunit-tests .qunit-assert-list .pass {
   color: var(--color-text-success);
   border-left: 10px solid var(--color-green);
 }
 
-#qunit-tests li p.qunit-source {
-  color: var(--color-gray-900);
-}
-
-ol.qunit-assert-list {
-  margin: 10px 0;
-}
-
-ol.qunit-assert-list .fail {
-  border-left: 0;
-}
-
-#qunit-tests li li.fail {
+#qunit-tests .qunit-assert-list .fail {
   border-left-color: var(--color-red);
 }
 
-#qunit-tests .fail .test-expected {
-  color: var(--color-green);
-}
-
-#qunit-tests .fail .test-actual {
-  color: var(--color-red);
+.qunit-source {
+  color: var(--color-gray-900);
 }
 
 #qunit-testrunner-toolbar button,
@@ -222,14 +224,6 @@ ol.qunit-assert-list .fail {
   color: var(--color-white);
 }
 
-#qunit-tests .pass {
-  background-color: var(--color-success);
-}
-
-#qunit-tests .fail {
-  background-color: var(--color-danger);
-}
-
 #qunit-testrunner-toolbar input[type="text"],
 #qunit-testrunner-toolbar #qunit-modulefilter-search {
   border: 1px solid var(--color-gray-300);
@@ -250,7 +244,8 @@ ol.qunit-assert-list .fail {
   border-color: var(--color-gray-300);
 }
 
-#qunit-modulefilter-search-container:after {
+/* QUnit 2 only */
+label[for="qunit-modulefilter-search"] + #qunit-modulefilter-search-container:after {
   content: "";
   width: var(--spacing-2);
   height: var(--spacing-2);


### PR DESCRIPTION
Tweak a few selectors so that the theme is compatible with QUnit 3.0 (currently in alpha).

| QUnit 3.0.0-alpha.2 | Before | After
|--|--|--
| <img width="1440" alt="Screenshot" src="https://github.com/user-attachments/assets/c805dd1e-258e-4b46-97ed-b2a55bf55007"> | <img width="1440" alt="Screenshot" src="https://github.com/user-attachments/assets/d51c051a-7293-47ca-b853-b82d8749d9c4"> | <img width="1440" alt="Screenshot" src="https://github.com/user-attachments/assets/1256f497-f48c-4bde-96e3-109664501fbe">




Reference:
* https://refined-github-html-preview.kidonng.workers.dev/IgnaceMaes/qunit-theme-ember/raw/main/test/index.html
* https://qunitjs.com/resources/example-add.html

----

* Limit `#qunit-tests li` to `#qunit-tests > li` so that the grey background won't start applying to assertions. Previously, upstream set its white background via `#qunit-tests li li.pass` which was stronger. QUnit 3.0.0-alpha.2 sets this on `.qunit-assert-list .pass` instead.
* Use `#qunit-tests > li` and `#qunit-tests > li.{pass,fail}` elsewhere too for consistency with the above and with (new) documentation at https://qunitjs.com/browser/#theme-api.
* Simplify `.qunit-source` selector, as that seems to be enough on both QUnit 2 and QUnit 3.
* Simplify `.qunit-assert-list` selector, idem.
* Use `#qunit-tests .qunit-assert-list .pass` instead of `#qunit-tests li li.pass`. In the future, `.qunit-assert-list .pass` should suffice but for now we need the ID in order for the theme to remain effective in QUnit 2 as well.
* Apply `#qunit-userAgent` override only in QUnit 2. In 3.0, the default might suite you better? (Text shadow was removed in https://github.com/qunitjs/qunit/pull/1774).
* Apply `#qunit-modulefilter-search-container:after` override only in QUnit 2. In 3.0, the positioning logic doesn't work right (icon shifted down). This could be fixed by setting `min-height` instead of `height`. But, given the icon was upstreamed in https://github.com/qunitjs/qunit/pull/1774, the default would achieve the same effect.